### PR TITLE
fix: Add Gradle 9 compatibility

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Wed Dec 04 11:21:35 EET 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/kotlin/dev/matrix/agp/rust/AndroidRustPlugin.kt
+++ b/src/main/kotlin/dev/matrix/agp/rust/AndroidRustPlugin.kt
@@ -9,15 +9,19 @@ import dev.matrix.agp.rust.utils.getAndroidExtension
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.tasks.TaskProvider
+import org.gradle.process.ExecOperations
 import java.io.File
 import java.util.Locale
+import javax.inject.Inject
 
 //
 // TODO: migrate to variant API with artifacts when JNI will be supported
 // https://developer.android.com/studio/build/extend-agp#access-modify-artifacts
 //
 @Suppress("unused")
-class AndroidRustPlugin : Plugin<Project> {
+abstract class AndroidRustPlugin @Inject constructor(
+    private val execOperations: ExecOperations
+) : Plugin<Project> {
     override fun apply(project: Project) {
         val rustBinaries = RustBinaries(project)
         val extension = project.extensions.create("androidRust", AndroidRustExtension::class.java)
@@ -86,7 +90,7 @@ class AndroidRustPlugin : Plugin<Project> {
             }
 
             val minimumSupportedRustVersion = SemanticVersion(extension.minimumSupportedRustVersion)
-            installRustComponentsIfNeeded(project, minimumSupportedRustVersion, allRustAbiSet, rustBinaries)
+            installRustComponentsIfNeeded(project, execOperations, minimumSupportedRustVersion, allRustAbiSet, rustBinaries)
         }
 
         androidComponents.onVariants { variant ->

--- a/src/main/kotlin/dev/matrix/agp/rust/RustBuildTask.kt
+++ b/src/main/kotlin/dev/matrix/agp/rust/RustBuildTask.kt
@@ -8,9 +8,14 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.TaskAction
+import org.gradle.process.ExecOperations
 import java.io.File
+import javax.inject.Inject
 
 internal abstract class RustBuildTask : DefaultTask() {
+    @get:Inject
+    abstract val execOperations: ExecOperations
+
     @get:Input
     abstract val rustBinaries: Property<RustBinaries>
 
@@ -66,7 +71,7 @@ internal abstract class RustBuildTask : DefaultTask() {
             .replace('-', '_')
             .uppercase()
 
-        project.exec {
+        execOperations.exec {
             standardOutput = System.out
             errorOutput = System.out
             workingDir = rustProjectDirectory

--- a/src/main/kotlin/dev/matrix/agp/rust/RustTestTask.kt
+++ b/src/main/kotlin/dev/matrix/agp/rust/RustTestTask.kt
@@ -4,9 +4,14 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.TaskAction
+import org.gradle.process.ExecOperations
 import java.io.File
+import javax.inject.Inject
 
 internal abstract class RustTestTask : DefaultTask() {
+    @get:Inject
+    abstract val execOperations: ExecOperations
+
     @get:Input
     abstract val rustProjectDirectory: Property<File>
 
@@ -18,7 +23,7 @@ internal abstract class RustTestTask : DefaultTask() {
         val rustProjectDirectory = rustProjectDirectory.get()
         val cargoTargetDirectory = cargoTargetDirectory.get()
 
-        project.exec {
+        execOperations.exec {
             standardOutput = System.out
             errorOutput = System.out
             workingDir = rustProjectDirectory


### PR DESCRIPTION
- Replace deprecated Project.exec() with ExecOperations
- Inject ExecOperations in AndroidRustPlugin, RustBuildTask, and RustTestTask
- Update RustInstaller functions to use ExecOperations
- Upgrade Gradle wrapper to 9.2.1

This fixes the build failure with Gradle 9.x where Project.exec() method was removed. The plugin now properly uses the ExecOperations service which is the recommended approach in Gradle 9+.