### PR TITLE
fix: Return all intersecting ABIs instead of just one

### DIFF
--- a/src/main/kotlin/dev/matrix/agp/rust/AndroidRustExtension.kt
+++ b/src/main/kotlin/dev/matrix/agp/rust/AndroidRustExtension.kt
@@ -11,6 +11,16 @@ open class AndroidRustExtension : AndroidRustConfiguration() {
     var minimumSupportedRustVersion = ""
     var modules = mutableMapOf<String, AndroidRustModule>()
 
+    /**
+     * Disable IDE ABI injection optimization.
+     * When true, all requested ABIs will be built regardless of IDE deployment target.
+     * When false (default), only the IDE target ABI will be built to speed up development builds.
+     *
+     * Set to true if you experience "library not found" errors when running from Android Studio.
+     * See: https://github.com/MatrixDev/GradleAndroidRustPlugin/issues/3
+     */
+    var disableAbiOptimization = false
+
     fun module(name: String, configure: AndroidRustModule.() -> Unit) {
         modules.getOrPut(name, ::AndroidRustModule).configure()
     }


### PR DESCRIPTION
The original logic had a critical bug: even when multiple ABIs were in the intersection, it would only return a single ABI based on priority (arm64 > x86_64 > first). This caused APKs to only contain one architecture's native libraries, leading to 'library not found' errors on other architectures.

Changes:
- Return all intersecting ABIs instead of selecting one
- Add disableAbiOptimization option for full control
- Properly pass extension parameter to resolveAbiList

This maintains IDE optimization (only build what's needed for deployment) while ensuring all necessary architectures are built.

Fixes: https://github.com/MatrixDev/GradleAndroidRustPlugin/issues/3